### PR TITLE
0.8.1

### DIFF
--- a/floodpack/data/minecraft/functions/chestspawns/midgamechest.mcfunction
+++ b/floodpack/data/minecraft/functions/chestspawns/midgamechest.mcfunction
@@ -1,6 +1,3 @@
 # Mid-game chest
-
-# Make more random chances (like 1/3?) for different locations, somewhat above the water level.
-
 setblock ~ ~60 ~ minecraft:chest{LootTable:"midgamechest"} replace
-summon firework_rocket ~ ~60 ~ {LifeTime:30,FireworksItem:{id:"firework_rocket",Count:1,tag:{Fireworks:{Flight:2,Explosions:[{Type:4,Flicker:1,Trail:1,Colors:[I;11743532],FadeColors:[I;11743532]}]}}}}
+summon firework_rocket ~ ~60 ~ {LifeTime:30,FireworksItem:{id:"firework_rocket",Count:1,tag:{Fireworks:{Flight:2,Explosions:[{Type:4,Flicker:1,Trail:1,Colors:[I;11743532],FadeColors:[I;11743532]}]}}}} 

--- a/floodpack/data/minecraft/functions/chestspawns/spawnlgchests.mcfunction
+++ b/floodpack/data/minecraft/functions/chestspawns/spawnlgchests.mcfunction
@@ -1,15 +1,15 @@
 # Summon 5 chest candidate location markers
-execute as @e[tag=waterLevel] at @s run summon marker ~ ~ ~ {"Tags":[chestCandidate]}
-execute as @e[tag=waterLevel] at @s run summon marker ~ ~ ~ {"Tags":[chestCandidate]}
-execute as @e[tag=waterLevel] at @s run summon marker ~ ~ ~ {"Tags":[chestCandidate]}
-execute as @e[tag=waterLevel] at @s run summon marker ~ ~ ~ {"Tags":[chestCandidate]}
-execute as @e[tag=waterLevel] at @s run summon marker ~ ~ ~ {"Tags":[chestCandidate]}
+summon marker ~ ~ ~ {"Tags":[chestCandidate]}
+summon marker ~ ~ ~ {"Tags":[chestCandidate]}
+summon marker ~ ~ ~ {"Tags":[chestCandidate]}
+summon marker ~ ~ ~ {"Tags":[chestCandidate]}
+summon marker ~ ~ ~ {"Tags":[chestCandidate]}
 
 # Spread out the location markers centered at 0,0; minimum distance of 10 apart; 20 block radius; not respecting teams; all entities with chestcandidate tag
 spreadplayers ~ ~ 10 20 false @e[tag=chestCandidate]
 
 # Pick 3 random chest candidates to spawn a chest on
-execute as @e[tag=chestCandidate,limit=3,sort=random] run function chestspawns/lategamechest
+execute as @e[tag=chestCandidate,limit=3,sort=random] at @s run function chestspawns/lategamechest
 
 # Remove the non-selected candidates
 execute as @e[tag=chestCandidate] at @s unless block ~ ~ ~ chest run kill @s

--- a/floodpack/data/minecraft/functions/chestspawns/spawnmgchests.mcfunction
+++ b/floodpack/data/minecraft/functions/chestspawns/spawnmgchests.mcfunction
@@ -1,15 +1,15 @@
 # Summon 5 chest candidate location markers
-execute as @e[tag=waterLevel] at @s run summon marker ~ ~ ~ {"Tags":[chestCandidate]}
-execute as @e[tag=waterLevel] at @s run summon marker ~ ~ ~ {"Tags":[chestCandidate]}
-execute as @e[tag=waterLevel] at @s run summon marker ~ ~ ~ {"Tags":[chestCandidate]}
-execute as @e[tag=waterLevel] at @s run summon marker ~ ~ ~ {"Tags":[chestCandidate]}
-execute as @e[tag=waterLevel] at @s run summon marker ~ ~ ~ {"Tags":[chestCandidate]}
+summon marker ~ ~ ~ {"Tags":[chestCandidate]}
+summon marker ~ ~ ~ {"Tags":[chestCandidate]}
+summon marker ~ ~ ~ {"Tags":[chestCandidate]}
+summon marker ~ ~ ~ {"Tags":[chestCandidate]}
+summon marker ~ ~ ~ {"Tags":[chestCandidate]}
 
 # Spread out the location markers centered at 0,0; minimum distance of 128 apart; 100 block radius; under ylv 288; not respecting teams; all entities with chestcandidate tag
 spreadplayers ~ ~ 128 100 under 288 false @e[tag=chestCandidate]
 
 # Pick 3 random chest candidates to spawn a chest on
-execute as @e[tag=chestCandidate,limit=3,sort=random] run function chestspawns/midgamechest
+execute as @e[tag=chestCandidate,limit=3,sort=random] at @s run function chestspawns/midgamechest
 
 # Remove the non-selected candidates
 execute as @e[tag=chestCandidate] at @s unless block ~ ~ ~ chest run kill @s

--- a/floodpack/data/minecraft/functions/initialize.mcfunction
+++ b/floodpack/data/minecraft/functions/initialize.mcfunction
@@ -12,6 +12,7 @@ setworldspawn 0 120 0
 scoreboard objectives add dummy dummy
 scoreboard objectives add yLevel dummy
 scoreboard objectives add deaths deathCount
+scoreboard objectives setdisplay sidebar yLevel
 
 # Enum constants
 scoreboard players set const5 dummy 5

--- a/floodpack/data/minecraft/functions/main.mcfunction
+++ b/floodpack/data/minecraft/functions/main.mcfunction
@@ -12,6 +12,10 @@ execute if predicate isthirdtrimester run function waterlvcalc/thirdtrimester
 execute unless predicate isreceding if score waterLevelTimer dummy matches 0 run schedule function flood 5t
 execute if predicate isreceding if score waterLevelTimer dummy matches 0 run schedule function drain 5t
 
+execute if score playTimeSec dummy matches 1 run function subfunctions/timetransitions
+execute if score playTimeSec dummy matches 321 run function subfunctions/timetransitions
+execute if score playTimeSec dummy matches 2561 run function subfunctions/timetransitions
+execute if score playTimeSec dummy matches 5921 run function subfunctions/timetransitions
 
 # Damage players who are in the water
 execute as @a at @s if predicate isunderflood run function subfunctions/swimmingdmg

--- a/floodpack/data/minecraft/functions/randomevents.mcfunction
+++ b/floodpack/data/minecraft/functions/randomevents.mcfunction
@@ -1,18 +1,15 @@
 # Top layer of water changes
 execute as @e[tag=waterLevel] at @s if predicate icechance run fill ~64 ~ ~64 ~-64 ~ ~-64 ice replace water
-execute as @e[tag=waterLevel] at @s if predicate icechance run fill ~64 ~ ~64 ~-64 ~ ~-64 lava replace water
 
 # Chest spawns
 execute as @e[tag=waterLevel] at @s if predicate midgamechestchance unless predicate isthirdtrimester run function chestspawns/spawnmgchests
 execute as @e[tag=waterLevel] at @s if predicate lategamechestchance if predicate isthirdtrimester run function chestspawns/lategamechest
-give @r salmon{Enchantments:[{id:knockback,lvl:30}]}
+execute if predicate defmobchance run give @r salmon{display:{Name:'[{"text":"LE FISCHE","italic":false}]',Lore:['[{"text":"au chocolat","italic":false}]']},Enchantments:[{id:knockback,lvl:8}]} 1
 
 # Random entity spawns
-execute as @e[tag=waterLevel] at @s if predicate guardianchance run summon guardian ~ ~ ~
-execute as @e[tag=waterLevel] at @s if predicate slimechance run summon slime ~ ~ ~ {Size:20}
-execute as @e[tag=waterLevel] at @s if predicate elderguardianchance run summon elder_guardian ~ ~ ~
-execute as @e[tag=waterLevel] at @s if predicate slimechance run summon minecraft:chicken ~ ~ ~ {Passengers:[{id:"zombie",IsBaby:1,CustomName:'[{"text":"BOB"}]',Health:50,CanPickUpLoot:1b,LeftHanded:1b,PersistenceRequired:1b,HandItems:[{id:"diamond_sword",tag:{Enchantments:[{id:fire_aspect,lvl:1},{id:sharpness,lvl:5}]},Count:1}],HandDropChances:[0.00f],ArmorItems:[{id:diamond_boots,tag:{Enchantments:[{id:protection,lvl:2}]},Count:1},{id:diamond_leggings,tag:{Enchantments:[{id:protection,lvl:1}]},Count:1},{id:diamond_chestplate,tag:{Enchantments:[{id:protection,lvl:1}]},Count:1},{id:diamond_helmet,tag:{Enchantments:[{id:protection,lvl:2}]},Count:1}],ArmorDropChances:[0.00f,0.00f,0.00f,0.00f],Attributes:[{Name:"generic.max_health",Base:50f}]}]}
-summon skeleton_horse
-summon lightning_bolt
-execute as @s at @s run summon minecraft:vex ~ ~ ~10 {Attributes:[{Name:"minecraft:generic.follow_range",Base:50d}],Passengers:[{id:creeper,Fuse:1,BlastRadius:5}]}
-
+execute as @e[tag=waterLevel] at @s unless predicate isreceding unless predicate isfirsttrimester if predicate guardianchance run summon guardian ~ ~ ~
+execute as @e[tag=waterLevel] at @s unless predicate isreceding unless predicate isfirsttrimester if predicate slimechance run summon slime ~ ~ ~ {Size:20}
+execute as @e[tag=waterLevel] at @s unless predicate isreceding unless predicate isfirsttrimester if predicate elderguardianchance run summon elder_guardian ~ ~ ~
+execute as @e[tag=waterLevel] at @s unless predicate isreceding unless predicate isfirsttrimester if predicate slimechance run summon minecraft:chicken ~ ~ ~ {Passengers:[{id:"zombie",IsBaby:1,CustomName:'[{"text":"BOB"}]',Health:20,CanPickUpLoot:1b,LeftHanded:1b,PersistenceRequired:1b,HandItems:[{id:"diamond_sword",tag:{Enchantments:[{id:fire_aspect,lvl:1},{id:sharpness,lvl:5}]},Count:1}],HandDropChances:[0.50f],ArmorItems:[{id:diamond_boots,tag:{Enchantments:[{id:protection,lvl:2}]},Count:1},{id:diamond_leggings,tag:{Enchantments:[{id:protection,lvl:1}]},Count:1},{id:diamond_chestplate,tag:{Enchantments:[{id:protection,lvl:1}]},Count:1},{id:diamond_helmet,tag:{Enchantments:[{id:protection,lvl:2}]},Count:1}],ArmorDropChances:[0.50f,0.50f,0.50f,0.50f],Attributes:[{Name:"generic.max_health",Base:20f}]}]}
+execute as @r at @s if predicate defmobchance unless predicate isreceding unless predicate isfirsttrimester run summon minecraft:skeleton_horse ~20 ~10 ~ {SkeletonTrap:1}
+execute as @r at @s if predicate defmobchance unless predicate isreceding unless predicate isfirsttrimester run summon minecraft:vex ~ ~10 ~ {Passengers:[{id:creeper,Fuse:1,BlastRadius:5}]}

--- a/floodpack/data/minecraft/functions/subfunctions/timetransitions.mcfunction
+++ b/floodpack/data/minecraft/functions/subfunctions/timetransitions.mcfunction
@@ -1,25 +1,25 @@
 # (R) Notify players that the game has started, and the water will begin to recede
-execute as @a at @s run playsound block.glass.break ambient @s ~ ~ ~
-tellraw @a ["",{"text":"PHASE R > ","bold":true},{"text":"Welcome to flood world. The water will now recede.","color":"gray"}]
+execute as @a at @s if predicate isreceding run playsound block.glass.break ambient @s ~ ~ ~
+execute if predicate isreceding run tellraw @a ["",{"text":"PHASE R > ","bold":true},{"text":"Welcome to flood world. The water will now recede.","color":"gray"}]
 
 # (1) Notify players that the water will now rise and there are mob spawns incoming
-execute as @a at @s run playsound entity.creeper.primed ambient @s ~ ~ ~
-tellraw @a ["",{"text":"PHASE 1 > ","bold":true},{"text":"The water is now rising. You may notice some wildlife floating in the water.","color":"gray"}]
+execute as @a at @s if predicate isfirsttrimester run playsound entity.creeper.primed ambient @s ~ ~ ~
+execute if predicate isfirsttrimester run tellraw @a ["",{"text":"PHASE 1 > ","bold":true},{"text":"The water is now rising. You may notice some wildlife in the water.","color":"gray"}]
 
 # (2) Notify players that they will no longer respawn
-execute as @a at @s run playsound entity.wither.death ambient @s ~ ~ ~
-execute as @a run title @s subtitle {"text":"You will no longer respawn!","color":"white"}
-execute as @a run title @s title {"text":"BED DESTROYED!","color":"red","bold":true}
+execute as @a at @s if predicate issecondtrimester run playsound entity.wither.death ambient @s ~ ~ ~
+execute as @a if predicate issecondtrimester run title @s subtitle {"text":"You will no longer respawn!","color":"white"}
+execute as @a if predicate issecondtrimester run title @s title {"text":"BED DESTROYED!","color":"red","bold":true}
 
-tellraw @a ["",{"text":"BED DESTRUCTION >","bold":true}," ",{"text":"Your bed was destroyed by","color":"gray"}," ",{"text":"oFinqls","color":"green"},{"text":"!","color":"gray"}]
-tellraw @a ["",{"text":"PHASE 2 > ","bold":true},{"text":"But actually. You won't respawn anymore, good luck.","color":"gray"}]
+execute if predicate issecondtrimester run tellraw @a ["",{"text":"BED DESTRUCTION >","bold":true}," ",{"text":"Your bed was destroyed by","color":"gray"}," ",{"text":"oFinqls","color":"green"},{"text":"!","color":"gray"}]
+execute if predicate issecondtrimester run tellraw @a ["",{"text":"PHASE 2 > ","bold":true},{"text":"But actually. You won't respawn anymore, good luck.","color":"gray"}]
 
 # (2) Shrink worldborder to 128 block diameter over 3360 seconds
-worldborder set 128 3360
+execute if predicate issecondtrimester run worldborder set 128 3360
 
 # (3) Notify players that phase 3, the final phase, has begun
-execute as @a at @s run playsound ambient.cave ambient @s ~ ~ ~
-tellraw @a ["",{"text":"PHASE 3 > ","bold":true},{"text":"The end is nigh. Now is a great time to fight another player.","color":"gray"}]
+execute as @a at @s if predicate isthirdtrimester run playsound ambient.cave ambient @s ~ ~ ~
+execute if predicate isthirdtrimester run tellraw @a ["",{"text":"PHASE 3 > ","bold":true},{"text":"The end is nigh, the rain crisis is infinite, and an apple a day... big shoes.","color":"gray"}]
 
 # (3) Shrink worldborder to 16 block diameter over 300 seconds
-worldborder set 16 300
+execute if predicate isthirdtrimester run worldborder set 16 300

--- a/floodpack/data/minecraft/predicates/defmobchance.json
+++ b/floodpack/data/minecraft/predicates/defmobchance.json
@@ -1,0 +1,5 @@
+{
+    "condition": "minecraft:random_chance",
+    "chance": 0.0003
+  }
+  

--- a/floodpack/data/minecraft/predicates/icechance.json
+++ b/floodpack/data/minecraft/predicates/icechance.json
@@ -1,4 +1,4 @@
 {
   "condition": "minecraft:random_chance",
-  "chance": 0.000416666
+  "chance": 0.0007
 }

--- a/floodpack/data/minecraft/predicates/isaftergame.json
+++ b/floodpack/data/minecraft/predicates/isaftergame.json
@@ -9,7 +9,7 @@
       "score": "dummy"
     },
     "range": {
-      "min": 7200
+      "min": 6525
     }
   }
   


### PR DESCRIPTION
Fully playtested to be functional, although with some caveats. Not a release candidate. Updates from 0.8:
- Fixed timetransitions.mcfunction not being called
- Fixed Le Fische being given to a random player once a  second
- Fixed mobs spawning before the second trimester
- Fixed skeleton traps spawning on players' heads, causing lightning to kill them
- Decreased spawn rate for vex-creepers and skeleton traps
- Set yLevel display to sidebar by default
- Added some animals to the current map (may change maps)

Known issues:
- Chests don't announce their location
- flood functions are not offset, which may cause extreme tick time spikes
- Chests spawn outside the worldborder during the second and third trimesters (despite my best efforts)
- Water does not reach 319; it's one block too low
- Ice events do not cover the entire map, only the original 128x128
- Want to add health objective and add arrows to loot tables
- completedrain doesn't run because postgame runs fully before completedrain does, thus killing the basis marker (fixed in next update)